### PR TITLE
Increase Default Metrics Search Limit to Max for Complete Discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nthienan/python:3.6.6-alpine3.8-onbuild as builder
+FROM nthienan/python:3.6.6-alpine3.8-onbuild AS builder
 
 RUN python setup.py clean bdist_wheel
 
@@ -22,5 +22,6 @@ RUN pip install --no-cache-dir sqe*.whl && \
     rm -f sqe*.whl
 
 COPY ./entrypoint.sh /usr/app/src/entrypoint.sh
+RUN chmod 777 /usr/app/src/entrypoint.sh
 
 ENTRYPOINT ["/usr/app/src/entrypoint.sh"]

--- a/src/sonarqube.py
+++ b/src/sonarqube.py
@@ -27,8 +27,8 @@ class SonarQubeClient:
     def get_projects(self, page_index=1, page_size=100):
         return self._request(endpoint="api/components/search?qualifiers=TRK&p={}&ps={}".format(page_index, page_size))
 
-    def get_metrics(self):
-        return self._request(endpoint="api/metrics/search?ps=500")
+    def get_metrics(self, page_size=500):
+        return self._request(endpoint="api/metrics/search?ps={}".format(page_size))
 
     def get_measures(self, component_key, metric_key):
         return self._request(endpoint="api/measures/component?component={}&metricKeys={}".format(component_key, metric_key))

--- a/src/sonarqube.py
+++ b/src/sonarqube.py
@@ -28,7 +28,7 @@ class SonarQubeClient:
         return self._request(endpoint="api/components/search?qualifiers=TRK&p={}&ps={}".format(page_index, page_size))
 
     def get_metrics(self):
-        return self._request(endpoint="api/metrics/search")
+        return self._request(endpoint="api/metrics/search?ps=500")
 
     def get_measures(self, component_key, metric_key):
         return self._request(endpoint="api/measures/component?component={}&metricKeys={}".format(component_key, metric_key))


### PR DESCRIPTION
### Pull Request Description

**Summary:**

This pull request updates the `get_metrics` method to enhance the metrics search functionality. The default page size for the metrics search has been increased from 100 (default) to 500. This change allows users to retrieve a larger set of metrics in a single request, improving usability.

**Changes Made:**

- Modified the `get_metrics` method to set the page size (`ps`) parameter to 500 in the API request.
- This ensures that all available metrics can be discovered.

Please review the changes and provide feedback. Thank you!
